### PR TITLE
nlohmann_json rebuild

### DIFF
--- a/recipe/bld.bat
+++ b/recipe/bld.bat
@@ -1,7 +1,7 @@
 cmake ^
 	-G "Ninja" ^
 	-D CMAKE_INSTALL_PREFIX=%LIBRARY_PREFIX% ^
-	-D BUILD_TESTING=OFF ^
+	-D JSON_BuildTests=OFF ^
 	%SRC_DIR%
 
 if errorlevel 1 exit 1

--- a/recipe/build.sh
+++ b/recipe/build.sh
@@ -4,7 +4,7 @@ cmake -G "Ninja" \
     -DCMAKE_INSTALL_PREFIX=$PREFIX \
     $SRC_DIR \
     -DCMAKE_INSTALL_LIBDIR=lib \
-    -DBUILD_TESTING=OFF \
+    -DJSON_BuildTests=OFF \
     -DJSON_MultipleHeaders=ON \
     ${CMAKE_ARGS}
 ninja install

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -25,7 +25,8 @@ build:
 requirements:
   build:
     - cmake
-    - ninja
+    - ninja-base
+    - {{ stdlib('c') }}
     - {{ compiler('c') }}
     - {{ compiler('cxx') }}
   host: []  # Empty host dependency section

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -10,7 +10,7 @@ source:
   sha256: 4b92eb0c06d10683f7447ce9406cb97cd4b453be18d7279320f7b2f025c10187
 
 build:
-  number: 0
+  number: 1
   skip: true  # [win and vc<14]
   # The json library is header only, so we do not need
   # to export the compiler run-time libraries.


### PR DESCRIPTION
nlohmann_json rebuild 

**Destination channel:** defaults

### Links

- [PKG-15392](https://anaconda.atlassian.net/browse/PKG-15392) 

### Explanation of changes:

- Use the correct upstream variable for disabling building tests
    - The main package builds and tests correctly on win-arm64, but building the tests fail. 
- Fix lints


[PKG-15392]: https://anaconda.atlassian.net/browse/PKG-15392?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ